### PR TITLE
Minor CSS Tweaks

### DIFF
--- a/src/scripts/TextureCard.ts
+++ b/src/scripts/TextureCard.ts
@@ -27,7 +27,7 @@ export class TextureCard
         data.source?.classList?.add('texture');
 
         this.dimension.innerHTML = `<span>&#127924;</span>&nbsp;&nbsp;${data.width} X ${data.height}`;
-        this.size.innerHTML = `<span>&#128190;</span>&nbsp;${mbSize}`;
+        this.size.innerHTML = `<span>&#128190;</span>&nbsp;&nbsp;${mbSize}`;
 
         data.cardHolder.classList.add('type-active');
 

--- a/src/scripts/styles/index.scss
+++ b/src/scripts/styles/index.scss
@@ -23,42 +23,39 @@ $filter-button-deleted-color: rgb(233, 30, 99);
     padding: 0;
 }
 
-body{
-    overflow: hidden;
-}
-
 #texture-monitor-container{
     font-family: Arial, Helvetica, sans-serif;
     background-color: $background-color;
-    position: absolute;
-    z-index: 1000;
+    font-size: 16px; // ROOT FONT SIZE FOR EM CALCULATIONS
+    position: fixed;
+    z-index: 100000;
     left: 0;
     bottom: 0;
     width: 100vw;
     transform: translateY(100%);
     transition: transform 0.25s ease-in-out;
     user-select: none;
-    height: 12.6rem;
-    padding: 1rem;
-    padding-left: 2.5rem;
+    height: 12.6em;
+    padding: 1em;
+    padding-left: 2.5em;
 
     .monitor-toggle{
         position: absolute;
         z-index: 1000;
-        left: 1.5rem;
-        top: 0.0625rem;
+        left: 1.5em;
+        top: 0.0625em;
         transform: translateY(-100%);
-        height: 2rem;
+        height: 2em;
         background-color: $primary-color;
-        border-radius: 0.2rem 0.2rem 0 0;
-        box-shadow: 0 -0.125rem 0.4375rem hsla(0, 0, 0, 0.3);
+        border-radius: 0.2em 0.2em 0 0;
+        box-shadow: 0 -0.125em 0.4375em hsla(0, 0, 0, 0.3);
         color: $white-color;
         display: flex;
         justify-content: center;
         align-content: center;
-        padding: 0.5rem 0.75rem;
+        padding: 0.5em 0.75em;
         cursor: pointer;
-        text-shadow: 0 0 0.8rem $primary-color;
+        text-shadow: 0 0 0.8em $primary-color;
         touch-action: pan-y;
 
         & > *{
@@ -68,10 +65,10 @@ body{
         span{
             background-color: $primary-color;
             text-shadow: none;
-            padding: 0.0rem 0.8rem;
-            border-radius: 0.1rem;
-            margin-left: 0.5rem;
-            box-shadow: 0 0 0.5rem $primary-color;
+            padding: 0.0em 0.8em;
+            border-radius: 0.1em;
+            margin-left: 0.5em;
+            box-shadow: 0 0 0.5em $primary-color;
         }
 
         #toggle-chevron{
@@ -90,27 +87,30 @@ body{
     .entities-wrapper{
         overflow-y: auto;
         display: grid;
-        grid-template-columns: repeat(auto-fill, 9.375rem);
+        grid-template-columns: repeat(auto-fill, 9.375em);
         height: 100%;
         width: 100%;
         position: relative;
         justify-content: center;
-        gap: 1rem;
-        padding: 0.79rem;
+        gap: 1em;
+        margin-top: 0.2em;
+        padding-right: 0.2em;
+        padding-left: 1.8em;
+        overscroll-behavior: contain;
 
         .texture-entity{
             position: relative;
             height: 100%;
 
             .texture-wrapper{
-                width: 9.375rem;
-                height: 6.375rem;
+                width: 9.375em;
+                height: 6.375em;
                 position: relative;
                 background-image: linear-gradient(45deg, #c7c7c7 25%, transparent 25%), linear-gradient(-45deg, #c7c7c7 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #c7c7c7 75%), linear-gradient(-45deg, transparent 75%, #c7c7c7 75%);
-                background-size: 1.875rem 1.875rem;
-                background-position: 0 0, 0 0.9375rem, 0.9375rem -0.9375rem, -0.9375rem 0;
+                background-size: 1.875em 1.875em;
+                background-position: 0 0, 0 0.9375em, 0.9375em -0.9375em, -0.9375em 0;
                 background-color: #777777;
-                border-radius: 0.1rem 0.1rem 0 0;
+                border-radius: 0.1em 0.1em 0 0;
 
                 .texture{
                     position: absolute;
@@ -125,14 +125,13 @@ body{
 
             .texture-info{
                 background-color: rgb(66, 80, 101);
-                padding: 0.2rem 0;
-                padding-left: 0.6rem;;
+                padding: 0.2em 0;
+                padding-left: 0.6em;;
                 color: $white-color;
-                border-radius: 0 0 0.1rem 0.1rem;
+                border-radius: 0 0 0.1em 0.1em;
                 width: 100%;
 
                 h4{
-                    margin-bottom: 0.2rem;
                     font-size: medium;
                 }
 
@@ -146,7 +145,7 @@ body{
             .extra-info{
                 position: absolute;
                 top:0;
-                height: 10.4rem;
+                height: 10.4em;
                 left: 0;
                 right: 0;
                 color: $white-color;
@@ -161,16 +160,16 @@ body{
 
                 h3{
                     font-size: medium;
-                    max-width: 9rem;
+                    max-width: 9em;
                     word-wrap: break-word;
                 }
 
                 div{
                     position: relative;
                     background-color: $primary-color;
-                    padding: 0.5rem 1.5rem;
-                    margin-top: 1rem;
-                    border-radius: 0.1rem;
+                    padding: 0.5em 1.5em;
+                    margin-top: 1em;
+                    border-radius: 0.1em;
                     transition: transform 0.1s ease-out;
                     cursor: pointer;
 
@@ -182,13 +181,13 @@ body{
                         left: 0;
                         right: 0;
                         border-radius: inherit;
-                        box-shadow: 0 0.5rem 0.6rem hsla(0, 0, 0, 0.5);
+                        box-shadow: 0 0.5em 0.6em hsla(0, 0, 0, 0.5);
                         opacity: 0;
                         transition: opacity 0.1s ease-out;
                     }
 
                     &:hover{
-                        transform: translateY(-0.1rem);
+                        transform: translateY(-0.1em);
 
                         &::before{
                             opacity: 1;
@@ -201,11 +200,11 @@ body{
                 content: '';
                 position: absolute;
                 top:0;
-                height: 9.8rem;
+                height: 10.4em;
                 left: 0;
                 right: 0;
                 background-color: hsla(0, 0, 0, 0.8);
-                border-radius: 0.1rem;
+                border-radius: 0.1em;
                 opacity: 0;
                 transition: opacity 0.1s ease-out;
             }
@@ -233,18 +232,18 @@ body{
         }
 
         &::-webkit-scrollbar-track{
-            box-shadow: inset 0 0 0.375rem rgba(0,0,0,0.3);
-            border-radius: 0.2rem;
+            box-shadow: inset 0 0 0.375em rgba(0,0,0,0.3);
+            border-radius: 0.2em;
             background-color: $scroll-secondary-color;
         }
 
         &::-webkit-scrollbar{
-            width: 0.75rem;
+            width: 0.75em;
         }
 
         &::-webkit-scrollbar-thumb{
-            border-radius: 0.2rem;
-            box-shadow: inset 0 0 0.375rem rgba(0,0,0,.3);
+            border-radius: 0.2em;
+            box-shadow: inset 0 0 0.375em rgba(0,0,0,.3);
             background-color: $scroll-primary-color;
         }
     }
@@ -254,24 +253,25 @@ body{
         display: flex;
         flex-direction: column;
         left: 0;
-        bottom: 2rem;
+        bottom: 2em;
 
+        // Hacky - Using px here instead to avoid em chained calculations
         .filter-button{
-            width: 5rem;
-            height: 1.5rem;
+            width: 80px;
+            height: 24px;
             display: flex;
             align-items: center;
             justify-content: center;
-            border-radius: 0 0.2rem 0.2rem 0;
+            border-radius: 0 3.2px 3.2px 0;
             color: $white-color;
             $filter-button-color: rgb(109, 109, 109);
             background-color: $filter-button-color;
-            box-shadow: 0 0.3rem 0 darken($filter-button-color, 20%);
+            box-shadow: 0 4.8px 0 darken($filter-button-color, 20%);
             position: relative;
             cursor: pointer;
-            transform: translateX(-0.5rem);
+            transform: translateX(-8px);
             transition: all 0.15s ease-out;
-            margin-bottom: 0.75rem;
+            margin-bottom: 12px;
             font-size: small;
 
             &:last-child{
@@ -300,28 +300,28 @@ body{
             }
 
             h2,h4{
-                margin-left: 0.25rem;
+                margin-left: 4px;
             }
 
             &.active{
                 $filter-button-color: $filter-button-active-color;
                 &.toggled{
                     background-color: $filter-button-color;
-                    box-shadow: 0 0.3rem 0 darken($filter-button-color, 10%);
+                    box-shadow: 0 4.8px 0 darken($filter-button-color, 10%);
                 }
             }
             &.deleted{
                 $filter-button-color: $filter-button-deleted-color;
                 &.toggled{
                     background-color: $filter-button-color;
-                    box-shadow: 0 0.3rem 0 darken($filter-button-color, 15%);
+                    box-shadow: 0 4.8px 0 darken($filter-button-color, 15%);
                 }
             }
             &.normal{
                 $filter-button-color: $filter-button-normal-color;
                 &.toggled{
                     background-color: $filter-button-color;
-                    box-shadow: 0 0.3rem 0 darken($filter-button-color, 15%);
+                    box-shadow: 0 4.8px 0 darken($filter-button-color, 15%);
                 }
             }
         }


### PR DESCRIPTION
- Changed to use fixed position rather than absolute and removed the body's overflow setting which should now correctly anchor the tool to the bottom of the viewport.
- Changed to used to use 'em' instead and set the tool container font size to default (16px) for 'em' to refer to. As some site will have font-size set on the root element, it can affect the rem calculation. There are a few hardcoded px fixes for some deep-nested elements which should be fine for now but will have to be addressed in the future if we want the tool to be resizable (For ticket #5 ).
- Other minor adjustments

**TODOs:**
- Investigate weird behaviour when used on Goodboy Digital website 